### PR TITLE
Switch to Ubuntu "slim"

### DIFF
--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -19,6 +19,7 @@ RUN opam switch 4.06.1
 RUN opam update
 RUN make build-deps
 RUN eval $(opam config env) && make
+RUN strip tezos-*
 RUN mkdir /_scripts && mkdir /_bin
 RUN cp -a scripts/docker/entrypoint.sh /_bin/ && \
     cp -a scripts/docker/entrypoint.inc.sh /_bin/ && \

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -1,21 +1,17 @@
 ######################## build ###############################
 
 FROM ubuntu:18.04 as builder
-RUN apt-get update
-RUN apt-get install -y build-essential git m4 unzip rsync curl libev-dev libgmp-dev pkg-config libhidapi-dev
-RUN apt-get install -y wget libcap2
-RUN wget http://security.ubuntu.com/ubuntu/pool/universe/b/bubblewrap/bubblewrap_0.2.1-1_amd64.deb
-RUN dpkg -i ./bubblewrap_0.2.1-1_amd64.deb
+RUN apt-get update && \
+    apt-get install -y build-essential git m4 unzip rsync curl libev-dev libgmp-dev pkg-config libhidapi-dev libcap2
 
 ARG net=mainnet
 RUN git clone -b $net https://gitlab.com/tezos/tezos.git
 WORKDIR tezos
 
-RUN wget https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux && \
-    mv opam-2.0.5-x86_64-linux /usr/local/bin/opam && \
+RUN curl -Lo - https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux >/usr/local/bin/opam && \
     chmod a+x /usr/local/bin/opam
-RUN opam init --comp=4.06.1 --disable-sandboxing
-RUN opam switch 4.06.1
+RUN opam init --comp=4.06.1 --disable-sandboxing && \
+    opam switch 4.06.1
 RUN opam update
 RUN make build-deps
 RUN eval $(opam config env) && make

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -10,6 +10,8 @@ WORKDIR tezos
 
 RUN curl -Lo - https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux >/usr/local/bin/opam && \
     chmod a+x /usr/local/bin/opam
+
+ENV OPAMROOTISOK=1
 RUN opam init --comp=4.06.1 --disable-sandboxing && \
     opam switch 4.06.1
 RUN opam update

--- a/Dockerfile-ubuntu
+++ b/Dockerfile-ubuntu
@@ -1,6 +1,6 @@
 ######################## build ###############################
 
-FROM ubuntu:latest as builder
+FROM ubuntu:18.04 as builder
 RUN apt-get update
 RUN apt-get install -y build-essential git m4 unzip rsync curl libev-dev libgmp-dev pkg-config libhidapi-dev
 RUN apt-get install -y wget libcap2
@@ -8,13 +8,12 @@ RUN wget http://security.ubuntu.com/ubuntu/pool/universe/b/bubblewrap/bubblewrap
 RUN dpkg -i ./bubblewrap_0.2.1-1_amd64.deb
 
 ARG net=mainnet
-RUN git clone https://gitlab.com/tezos/tezos.git
+RUN git clone -b $net https://gitlab.com/tezos/tezos.git
 WORKDIR tezos
-RUN git checkout $net 
 
-RUN wget https://github.com/ocaml/opam/releases/download/2.0.0-rc4/opam-2.0.0-rc4-x86_64-linux
-RUN mv opam-2.0.0-rc4-x86_64-linux /usr/local/bin/opam
-RUN chmod a+x /usr/local/bin/opam
+RUN wget https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux && \
+    mv opam-2.0.5-x86_64-linux /usr/local/bin/opam && \
+    chmod a+x /usr/local/bin/opam
 RUN opam init --comp=4.06.1 --disable-sandboxing
 RUN opam switch 4.06.1
 RUN opam update
@@ -22,21 +21,19 @@ RUN make build-deps
 RUN eval $(opam config env) && make
 RUN mkdir /_scripts && mkdir /_bin
 RUN cp -a scripts/docker/entrypoint.sh /_bin/ && \
-  cp -a scripts/docker/entrypoint.inc.sh /_bin/ && \
-  cp scripts/alphanet.sh /_scripts/ && \
-  cp scripts/alphanet_version /_scripts/ && \
-  cp src/bin_client/bash-completion.sh /_scripts/ && \
-  cp active_protocol_versions /_scripts/
+    cp -a scripts/docker/entrypoint.inc.sh /_bin/ && \
+    cp scripts/alphanet.sh /_scripts/ && \
+    cp scripts/alphanet_version /_scripts/ && \
+    cp src/bin_client/bash-completion.sh /_scripts/ && \
+    cp active_protocol_versions /_scripts/
 
 ######################### final ###############################
 
-FROM ubuntu:latest as final
+FROM ubuntu:18.04 as final
 
 RUN apt-get update && \
-  apt-get install -y libev-dev libgmp-dev libhidapi-dev netbase && \
-  apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN mkdir -p /var/run/tezos/node /var/run/tezos/client
+    apt-get install -y libev-dev libgmp-dev libhidapi-dev netbase && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=builder /_scripts/* /usr/local/share/tezos/
 COPY --from=builder /_bin/* /usr/local/bin/
@@ -51,6 +48,10 @@ COPY --from=builder /tezos/tezos-protocol-compiler /usr/local/bin/
 COPY --from=builder /tezos/tezos-signer /usr/local/bin/
 
 RUN useradd -ms /bin/bash tezos
+
+RUN mkdir -p /var/run/tezos/node /var/run/tezos/client && \
+    chown tezos /var/run/tezos/node /var/run/tezos/client
+
 USER tezos
 ENV USER=tezos
 


### PR DESCRIPTION
Ubuntu announced "slim" versions of Ubuntu based on 18.04. Per their announcement,
https://ubuntu.com/blog/minimal-ubuntu-released, if you specifically pull `ubuntu:18.04`, then you automatically get the slim image.

Several minor modifications to merge some build stages.

```
$ docker build -t checker -f Dockerfile-ubuntu .
...
$ docker images
REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
checker                  latest              04ffd2e4b87c        3 minutes ago       445MB
```

The tezos binaries themselves (tezos-*) sum to 399MB. Geez that's a lot of bloat.